### PR TITLE
fix: correct the classname of page heading

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,6 +8,6 @@
   </head>
 
   <body>
-    <h1 class="some-heading">GIT WORKFLOW WORKSHOW</h1>
+    <h1 class="page-heading">GIT WORKFLOW WORKSHOW</h1>
   </body>
 </html>


### PR DESCRIPTION
Relates #4
Fixed class name for h1 element to 'page-heading'